### PR TITLE
datagen proof of concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ run
 .gitattributes
 deps
 src/generated
+script/__pycache__/structures.cpython-310.pyc

--- a/datapacks/forge/src/main/resources/assets/repurposed_structures/lang/en_us.json
+++ b/datapacks/forge/src/main/resources/assets/repurposed_structures/lang/en_us.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "repurposed_structures.advancements.structure_advancements.ancient_cities.title": "Civilization from the Beyond",
+  "repurposed_structures.advancements.structure_advancements.ancient_cities.description": "Find all new Ancient Cities"
+}

--- a/datapacks/forge/src/main/resources/data/repurposed_structures/advancements/structure_advancements/ancient_cities.json
+++ b/datapacks/forge/src/main/resources/data/repurposed_structures/advancements/structure_advancements/ancient_cities.json
@@ -1,0 +1,81 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "parent": "repurposed_structures:structure_advancements/root",
+  "criteria": {
+    "repurposed_structures:ancient_city_nether": {
+      "trigger": "minecraft:location",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "location": {
+                "structure": "repurposed_structures:ancient_city_nether"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "repurposed_structures:ancient_city_end": {
+      "trigger": "minecraft:location",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "location": {
+                "structure": "repurposed_structures:ancient_city_end"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "repurposed_structures:ancient_city_ocean": {
+      "trigger": "minecraft:location",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "location": {
+                "structure": "repurposed_structures:ancient_city_ocean"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "display": {
+    "icon": {
+      "item": "minecraft:reinforced_deepslate"
+    },
+    "title": {
+      "translate": "repurposed_structures.advancements.structure_advancements.ancient_cities.title"
+    },
+    "description": {
+      "translate": "repurposed_structures.advancements.structure_advancements.ancient_cities.description"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false,
+    "background": "minecraft:textures/block/dirt.png"
+  },
+  "requirements": [
+    [
+      "repurposed_structures:ancient_city_nether"
+    ],
+    [
+      "repurposed_structures:ancient_city_end"
+    ],
+    [
+      "repurposed_structures:ancient_city_ocean"
+    ]
+  ]
+}

--- a/datapacks/forge/src/main/resources/data/repurposed_structures/tags/worldgen/biome/has_structure/ancient_cities/end.json
+++ b/datapacks/forge/src/main/resources/data/repurposed_structures/tags/worldgen/biome/has_structure/ancient_cities/end.json
@@ -1,0 +1,7 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "replace": false,
+  "values": [
+    "repurposed_structures:end"
+  ]
+}

--- a/datapacks/forge/src/main/resources/data/repurposed_structures/tags/worldgen/biome/has_structure/ancient_cities/nether.json
+++ b/datapacks/forge/src/main/resources/data/repurposed_structures/tags/worldgen/biome/has_structure/ancient_cities/nether.json
@@ -1,0 +1,7 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "replace": false,
+  "values": [
+    "repurposed_structures:nether"
+  ]
+}

--- a/datapacks/forge/src/main/resources/data/repurposed_structures/tags/worldgen/biome/has_structure/ancient_cities/ocean.json
+++ b/datapacks/forge/src/main/resources/data/repurposed_structures/tags/worldgen/biome/has_structure/ancient_cities/ocean.json
@@ -1,0 +1,7 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "replace": false,
+  "values": [
+    "repurposed_structures:ocean"
+  ]
+}

--- a/datapacks/forge/src/main/resources/data/repurposed_structures/tags/worldgen/structure/collections/ancient_cities.json
+++ b/datapacks/forge/src/main/resources/data/repurposed_structures/tags/worldgen/structure/collections/ancient_cities.json
@@ -1,0 +1,9 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "replace": false,
+  "values": [
+    "repurposed_structures:ancient_city_nether",
+    "repurposed_structures:ancient_city_end",
+    "repurposed_structures:ancient_city_ocean"
+  ]
+}

--- a/datapacks/forge/src/main/resources/data/repurposed_structures/worldgen/structure/ancient_city_end.json
+++ b/datapacks/forge/src/main/resources/data/repurposed_structures/worldgen/structure/ancient_city_end.json
@@ -1,0 +1,35 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "type": "repurposed_structures:generic_jigsaw_structure",
+  "start_pool": "repurposed_structures:ancient_cities/end/start_pool",
+  "size": 7,
+  "biomes": "#repurposed_structures:has_structure:/ancient_cities/end",
+  "cannot_spawn_in_liquid": true,
+  "terrain_adaptation": "beard_box",
+  "step": "surface_structures",
+  "min_y_allowed": 45,
+  "terrain_height_radius_check": 3,
+  "burying_type": "AVERAGE_LAND",
+  "start_height": {
+    "absolute": -3
+  },
+  "spawn_overrides": {
+    "monster": {
+      "bounding_box": "full",
+      "spawns": [
+        {
+          "type": "minecraft:phantom",
+          "weight": 3,
+          "min_count": 1,
+          "max_count": 1
+        },
+        {
+          "type": "minecraft:endermite",
+          "weight": 2,
+          "min_count": 3,
+          "max_count": 7
+        }
+      ]
+    }
+  }
+}

--- a/datapacks/forge/src/main/resources/data/repurposed_structures/worldgen/structure/ancient_city_nether.json
+++ b/datapacks/forge/src/main/resources/data/repurposed_structures/worldgen/structure/ancient_city_nether.json
@@ -1,0 +1,35 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "type": "repurposed_structures:generic_jigsaw_structure",
+  "start_pool": "repurposed_structures:ancient_cities/nether/start_pool",
+  "size": 7,
+  "biomes": "#repurposed_structures:has_structure:/ancient_cities/nether",
+  "cannot_spawn_in_liquid": true,
+  "terrain_adaptation": "beard_box",
+  "step": "surface_structures",
+  "min_y_allowed": 45,
+  "terrain_height_radius_check": 3,
+  "burying_type": "AVERAGE_LAND",
+  "start_height": {
+    "absolute": -3
+  },
+  "spawn_overrides": {
+    "monster": {
+      "bounding_box": "full",
+      "spawns": [
+        {
+          "type": "minecraft:phantom",
+          "weight": 3,
+          "min_count": 1,
+          "max_count": 1
+        },
+        {
+          "type": "minecraft:endermite",
+          "weight": 2,
+          "min_count": 3,
+          "max_count": 7
+        }
+      ]
+    }
+  }
+}

--- a/datapacks/forge/src/main/resources/data/repurposed_structures/worldgen/structure/ancient_city_ocean.json
+++ b/datapacks/forge/src/main/resources/data/repurposed_structures/worldgen/structure/ancient_city_ocean.json
@@ -1,0 +1,35 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "type": "repurposed_structures:generic_jigsaw_structure",
+  "start_pool": "repurposed_structures:ancient_cities/ocean/start_pool",
+  "size": 7,
+  "biomes": "#repurposed_structures:has_structure:/ancient_cities/ocean",
+  "cannot_spawn_in_liquid": true,
+  "terrain_adaptation": "beard_box",
+  "step": "surface_structures",
+  "min_y_allowed": 45,
+  "terrain_height_radius_check": 3,
+  "burying_type": "AVERAGE_LAND",
+  "start_height": {
+    "absolute": -3
+  },
+  "spawn_overrides": {
+    "monster": {
+      "bounding_box": "full",
+      "spawns": [
+        {
+          "type": "minecraft:phantom",
+          "weight": 3,
+          "min_count": 1,
+          "max_count": 1
+        },
+        {
+          "type": "minecraft:endermite",
+          "weight": 2,
+          "min_count": 3,
+          "max_count": 7
+        }
+      ]
+    }
+  }
+}

--- a/datapacks/forge/src/main/resources/data/repurposed_structures/worldgen/structure_set/ancient_cities_end.json
+++ b/datapacks/forge/src/main/resources/data/repurposed_structures/worldgen/structure_set/ancient_cities_end.json
@@ -1,0 +1,15 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "structures": [
+    {
+      "structure": "repurposed_structures:ancient_city_end",
+      "weight": 1
+    }
+  ],
+  "placement": {
+    "type": "repurposed_structures:advanced_random_spread",
+    "salt": 112448534,
+    "spacing": 130,
+    "separation": 65
+  }
+}

--- a/datapacks/forge/src/main/resources/data/repurposed_structures/worldgen/structure_set/ancient_cities_nether.json
+++ b/datapacks/forge/src/main/resources/data/repurposed_structures/worldgen/structure_set/ancient_cities_nether.json
@@ -1,0 +1,15 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "structures": [
+    {
+      "structure": "repurposed_structures:ancient_city_nether",
+      "weight": 1
+    }
+  ],
+  "placement": {
+    "type": "repurposed_structures:advanced_random_spread",
+    "salt": 112448534,
+    "spacing": 130,
+    "separation": 65
+  }
+}

--- a/datapacks/forge/src/main/resources/data/repurposed_structures/worldgen/structure_set/ancient_cities_ocean.json
+++ b/datapacks/forge/src/main/resources/data/repurposed_structures/worldgen/structure_set/ancient_cities_ocean.json
@@ -1,0 +1,15 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "structures": [
+    {
+      "structure": "repurposed_structures:ancient_city_ocean",
+      "weight": 1
+    }
+  ],
+  "placement": {
+    "type": "repurposed_structures:advanced_random_spread",
+    "salt": 112448534,
+    "spacing": 130,
+    "separation": 65
+  }
+}

--- a/datapacks/quilt/src/main/resources/assets/repurposed_structures/lang/en_us.json
+++ b/datapacks/quilt/src/main/resources/assets/repurposed_structures/lang/en_us.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "repurposed_structures.advancements.structure_advancements.ancient_cities.title": "Civilization from the Beyond",
+  "repurposed_structures.advancements.structure_advancements.ancient_cities.description": "Find all new Ancient Cities"
+}

--- a/datapacks/quilt/src/main/resources/data/repurposed_structures/advancements/structure_advancements/ancient_cities.json
+++ b/datapacks/quilt/src/main/resources/data/repurposed_structures/advancements/structure_advancements/ancient_cities.json
@@ -1,0 +1,81 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "parent": "repurposed_structures:structure_advancements/root",
+  "criteria": {
+    "repurposed_structures:ancient_city_nether": {
+      "trigger": "minecraft:location",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "location": {
+                "structure": "repurposed_structures:ancient_city_nether"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "repurposed_structures:ancient_city_end": {
+      "trigger": "minecraft:location",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "location": {
+                "structure": "repurposed_structures:ancient_city_end"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "repurposed_structures:ancient_city_ocean": {
+      "trigger": "minecraft:location",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "location": {
+                "structure": "repurposed_structures:ancient_city_ocean"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "display": {
+    "icon": {
+      "item": "minecraft:reinforced_deepslate"
+    },
+    "title": {
+      "translate": "repurposed_structures.advancements.structure_advancements.ancient_cities.title"
+    },
+    "description": {
+      "translate": "repurposed_structures.advancements.structure_advancements.ancient_cities.description"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false,
+    "background": "minecraft:textures/block/dirt.png"
+  },
+  "requirements": [
+    [
+      "repurposed_structures:ancient_city_nether"
+    ],
+    [
+      "repurposed_structures:ancient_city_end"
+    ],
+    [
+      "repurposed_structures:ancient_city_ocean"
+    ]
+  ]
+}

--- a/datapacks/quilt/src/main/resources/data/repurposed_structures/tags/worldgen/biome/has_structure/ancient_cities/end.json
+++ b/datapacks/quilt/src/main/resources/data/repurposed_structures/tags/worldgen/biome/has_structure/ancient_cities/end.json
@@ -1,0 +1,7 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "replace": false,
+  "values": [
+    "repurposed_structures:end"
+  ]
+}

--- a/datapacks/quilt/src/main/resources/data/repurposed_structures/tags/worldgen/biome/has_structure/ancient_cities/nether.json
+++ b/datapacks/quilt/src/main/resources/data/repurposed_structures/tags/worldgen/biome/has_structure/ancient_cities/nether.json
@@ -1,0 +1,7 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "replace": false,
+  "values": [
+    "repurposed_structures:nether"
+  ]
+}

--- a/datapacks/quilt/src/main/resources/data/repurposed_structures/tags/worldgen/biome/has_structure/ancient_cities/ocean.json
+++ b/datapacks/quilt/src/main/resources/data/repurposed_structures/tags/worldgen/biome/has_structure/ancient_cities/ocean.json
@@ -1,0 +1,7 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "replace": false,
+  "values": [
+    "repurposed_structures:ocean"
+  ]
+}

--- a/datapacks/quilt/src/main/resources/data/repurposed_structures/tags/worldgen/structure/collections/ancient_cities.json
+++ b/datapacks/quilt/src/main/resources/data/repurposed_structures/tags/worldgen/structure/collections/ancient_cities.json
@@ -1,0 +1,9 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "replace": false,
+  "values": [
+    "repurposed_structures:ancient_city_nether",
+    "repurposed_structures:ancient_city_end",
+    "repurposed_structures:ancient_city_ocean"
+  ]
+}

--- a/datapacks/quilt/src/main/resources/data/repurposed_structures/worldgen/structure/ancient_city_end.json
+++ b/datapacks/quilt/src/main/resources/data/repurposed_structures/worldgen/structure/ancient_city_end.json
@@ -1,0 +1,35 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "type": "repurposed_structures:generic_jigsaw_structure",
+  "start_pool": "repurposed_structures:ancient_cities/end/start_pool",
+  "size": 7,
+  "biomes": "#repurposed_structures:has_structure:/ancient_cities/end",
+  "cannot_spawn_in_liquid": true,
+  "terrain_adaptation": "beard_box",
+  "step": "surface_structures",
+  "min_y_allowed": 45,
+  "terrain_height_radius_check": 3,
+  "burying_type": "AVERAGE_LAND",
+  "start_height": {
+    "absolute": -3
+  },
+  "spawn_overrides": {
+    "monster": {
+      "bounding_box": "full",
+      "spawns": [
+        {
+          "type": "minecraft:phantom",
+          "weight": 3,
+          "min_count": 1,
+          "max_count": 1
+        },
+        {
+          "type": "minecraft:endermite",
+          "weight": 2,
+          "min_count": 3,
+          "max_count": 7
+        }
+      ]
+    }
+  }
+}

--- a/datapacks/quilt/src/main/resources/data/repurposed_structures/worldgen/structure/ancient_city_nether.json
+++ b/datapacks/quilt/src/main/resources/data/repurposed_structures/worldgen/structure/ancient_city_nether.json
@@ -1,0 +1,35 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "type": "repurposed_structures:generic_jigsaw_structure",
+  "start_pool": "repurposed_structures:ancient_cities/nether/start_pool",
+  "size": 7,
+  "biomes": "#repurposed_structures:has_structure:/ancient_cities/nether",
+  "cannot_spawn_in_liquid": true,
+  "terrain_adaptation": "beard_box",
+  "step": "surface_structures",
+  "min_y_allowed": 45,
+  "terrain_height_radius_check": 3,
+  "burying_type": "AVERAGE_LAND",
+  "start_height": {
+    "absolute": -3
+  },
+  "spawn_overrides": {
+    "monster": {
+      "bounding_box": "full",
+      "spawns": [
+        {
+          "type": "minecraft:phantom",
+          "weight": 3,
+          "min_count": 1,
+          "max_count": 1
+        },
+        {
+          "type": "minecraft:endermite",
+          "weight": 2,
+          "min_count": 3,
+          "max_count": 7
+        }
+      ]
+    }
+  }
+}

--- a/datapacks/quilt/src/main/resources/data/repurposed_structures/worldgen/structure/ancient_city_ocean.json
+++ b/datapacks/quilt/src/main/resources/data/repurposed_structures/worldgen/structure/ancient_city_ocean.json
@@ -1,0 +1,35 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "type": "repurposed_structures:generic_jigsaw_structure",
+  "start_pool": "repurposed_structures:ancient_cities/ocean/start_pool",
+  "size": 7,
+  "biomes": "#repurposed_structures:has_structure:/ancient_cities/ocean",
+  "cannot_spawn_in_liquid": true,
+  "terrain_adaptation": "beard_box",
+  "step": "surface_structures",
+  "min_y_allowed": 45,
+  "terrain_height_radius_check": 3,
+  "burying_type": "AVERAGE_LAND",
+  "start_height": {
+    "absolute": -3
+  },
+  "spawn_overrides": {
+    "monster": {
+      "bounding_box": "full",
+      "spawns": [
+        {
+          "type": "minecraft:phantom",
+          "weight": 3,
+          "min_count": 1,
+          "max_count": 1
+        },
+        {
+          "type": "minecraft:endermite",
+          "weight": 2,
+          "min_count": 3,
+          "max_count": 7
+        }
+      ]
+    }
+  }
+}

--- a/datapacks/quilt/src/main/resources/data/repurposed_structures/worldgen/structure_set/ancient_cities_end.json
+++ b/datapacks/quilt/src/main/resources/data/repurposed_structures/worldgen/structure_set/ancient_cities_end.json
@@ -1,0 +1,15 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "structures": [
+    {
+      "structure": "repurposed_structures:ancient_city_end",
+      "weight": 1
+    }
+  ],
+  "placement": {
+    "type": "repurposed_structures:advanced_random_spread",
+    "salt": 112448534,
+    "spacing": 130,
+    "separation": 65
+  }
+}

--- a/datapacks/quilt/src/main/resources/data/repurposed_structures/worldgen/structure_set/ancient_cities_nether.json
+++ b/datapacks/quilt/src/main/resources/data/repurposed_structures/worldgen/structure_set/ancient_cities_nether.json
@@ -1,0 +1,15 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "structures": [
+    {
+      "structure": "repurposed_structures:ancient_city_nether",
+      "weight": 1
+    }
+  ],
+  "placement": {
+    "type": "repurposed_structures:advanced_random_spread",
+    "salt": 112448534,
+    "spacing": 130,
+    "separation": 65
+  }
+}

--- a/datapacks/quilt/src/main/resources/data/repurposed_structures/worldgen/structure_set/ancient_cities_ocean.json
+++ b/datapacks/quilt/src/main/resources/data/repurposed_structures/worldgen/structure_set/ancient_cities_ocean.json
@@ -1,0 +1,15 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "structures": [
+    {
+      "structure": "repurposed_structures:ancient_city_ocean",
+      "weight": 1
+    }
+  ],
+  "placement": {
+    "type": "repurposed_structures:advanced_random_spread",
+    "salt": 112448534,
+    "spacing": 130,
+    "separation": 65
+  }
+}

--- a/script/generate_resources.py
+++ b/script/generate_resources.py
@@ -1,0 +1,38 @@
+import argparse
+from typing import Sequence
+
+from mcresources import ResourceManager, utils
+from mcresources.type_definitions import Json
+
+import structures
+
+FORGE_PATH = '../datapacks/forge/src/main/resources'
+QUILT_PATH = '../datapacks/quilt/src/main/resources'
+
+def generate_at_path(path: str):
+    parser = argparse.ArgumentParser(description='Generate resources for Firmalife')
+    rm = ResourceManager('repurposed_structures', resource_dir=path)
+    parser.add_argument('--clean', action='store_true', dest='clean', help='Clean all auto generated resources')
+    args = parser.parse_args()
+
+    if args.clean:
+        for tries in range(1, 1 + 3):
+            try:
+                utils.clean_generated_resources('/'.join(rm.resource_dir))
+                print('Clean Success')
+                return
+            except:
+                print('Failed, retrying (%d / 3)' % tries)
+        print('Clean Aborted')
+        return
+
+    generate_all(rm)
+    print('New = %d, Modified = %d, Unchanged = %d, Errors = %d' % (rm.new_files, rm.modified_files, rm.unchanged_files, rm.error_files))
+
+
+def generate_all(rm: ResourceManager):
+    structures.generate(rm)
+
+if __name__ == '__main__':
+    generate_at_path(FORGE_PATH)
+    generate_at_path(QUILT_PATH)

--- a/script/generate_resources.py
+++ b/script/generate_resources.py
@@ -27,6 +27,7 @@ def generate_at_path(path: str):
         return
 
     generate_all(rm)
+    rm.flush()
     print('New = %d, Modified = %d, Unchanged = %d, Errors = %d' % (rm.new_files, rm.modified_files, rm.unchanged_files, rm.error_files))
 
 

--- a/script/structures.py
+++ b/script/structures.py
@@ -1,0 +1,104 @@
+from distutils.spawn import spawn
+from typing import Dict, Any, Tuple
+
+from mcresources import ResourceManager, utils
+from mcresources.type_definitions import JsonObject
+from mcresources.advancements import *
+
+GENERIC_JIGSAW = 'repurposed_structures:generic_jigsaw_structure'
+ANCIENT_CITY_VARIANTS = ('nether', 'end', 'ocean')
+
+def generate(rm: ResourceManager):
+    category = AdvancementCategory(rm, 'structure_advancements', 'minecraft:textures/block/dirt.png')
+
+    for variant in ANCIENT_CITY_VARIANTS:
+        configured_structure(rm, 'ancient_city', GENERIC_JIGSAW, variant, 7, {
+            'min_y_allowed': 45,
+            'terrain_height_radius_check': 3,
+            'burying_type': 'AVERAGE_LAND',
+            'start_height': {
+                'absolute': -3
+            },
+            'spawn_overrides': {'monster': spawn_override(spawner('minecraft:phantom', 3), spawner('minecraft:endermite', 2, 3, 7))}
+        }
+        )
+        full_name = pluralize('repurposed_structures:ancient_city') + '_' + variant
+        structure_set(rm, full_name, 112448534, 130, 65, ('repurposed_structures:ancient_city_%s' % variant, 1))
+    advancement(rm, category, 'ancient_cities', 'minecraft:reinforced_deepslate', 'Civilization from the Beyond', 'Find all new Ancient Cities', *['repurposed_structures:ancient_city_%s' % v for v in ANCIENT_CITY_VARIANTS])
+
+
+def pluralize(structure_type: str) -> str:
+    return structure_type if structure_type.endswith('s') else ((structure_type[:-1] + 'ies') if structure_type.endswith('y') else (structure_type + 's'));
+
+def configured_structure(rm: ResourceManager, base_name: str, structure_type: str, variant: str, size: int, config: Dict[str, Any], no_liquid: bool = True, terrain_adapt: str = 'beard_box', step: str = 'surface_structures', heightmap: str = None, valid_biome_radius: int = None):
+    structure_type_plural = pluralize(base_name)
+    name = f'{base_name}_{variant}'
+    rm.write((*rm.resource_dir, 'data', rm.domain, 'worldgen', 'structure', name), {
+        'type': structure_type,
+        'start_pool': '%s:%s/%s/start_pool' % (rm.domain, structure_type_plural, variant),
+        'size': size,
+        'biomes': '#%s:has_structure:/%s/%s' % (rm.domain, structure_type_plural, variant),
+        'cannot_spawn_in_liquid': no_liquid,
+        'terrain_adaptation': terrain_adapt,
+        'step': step,
+        'project_start_to_heightmap': heightmap,
+        'valid_biome_radius_check': valid_biome_radius,
+        **config
+    })
+
+    rm.tag(structure_type_plural, 'worldgen/structure/collections', '%s:%s' % (rm.domain, name))
+    rm.tag('%s/%s' % (structure_type_plural, variant), 'worldgen/biome/has_structure', '%s:%s' % (rm.domain, variant))
+
+def spawn_override(*spawns: Dict[str, Any], bounding_box: str = 'full') -> JsonObject:
+    return {
+        'bounding_box': bounding_box,
+        'spawns': [s for s in spawns]
+    }
+
+def spawner(entity_type: str, weight: int = 1, min_count: int = 1, max_count: int = 1) -> JsonObject:
+    return {
+        'type': entity_type,
+        'weight': weight if weight != 1 else None,
+        'min_count': min_count,
+        'max_count': max_count
+    }
+
+def structure_set(rm: ResourceManager, name: str, salt: int, spacing: int, separation: int, *structures: Tuple[str, int], placement_type: str = 'repurposed_structures:advanced_random_spread'):
+    res = utils.resource_location(rm.domain, name)
+    rm.write((*rm.resource_dir, 'data', res.domain, 'worldgen', 'structure_set', res.path), { 
+        'structures': [
+            {
+                'structure': s,
+                'weight': w
+            }
+            for s, w, in structures
+        ],
+        'placement': {
+            'type': placement_type,
+            'salt': salt,
+            'spacing': spacing,
+            'separation': separation
+        }
+    })
+
+def advancement(rm: ResourceManager, category: AdvancementCategory, name: str, icon: str, title: str, description: str, *structures: str, exp: int = 1000):
+    category.advancement(name, icon, title, description, 'root', criteria=dict({structure: structure_trigger(structure) for structure in structures}), requirements=[[s] for s in structures])
+
+
+def structure_trigger(structure: str) -> JsonObject:
+    return {
+        'trigger': 'minecraft:location',
+        'conditions': {
+            'player': [
+                {
+                    'condition': 'minecraft:entity_properties',
+                    'entity': 'this',
+                    'predicate': {
+                        'location': {
+                            'structure': structure
+                        }
+                    }
+                }
+            ]
+        }
+    }


### PR DESCRIPTION
Hi Tele,

So I was wanting to bring vanilla structures to a TFC addon, but I realized that you had already done most of the work of converting vanilla structures to usable jigsaw files. However given the scale of stuff I'd want to do, generally the suggestion for modders has been to download the example datapack and edit it yourself. I really prefer to datagen things in this case, as it helps keep the changes to the files in version control and in one place, and helps to standardize everything. It also improves the speed at which adding things takes.

So I looked and noticed that you were doing it to some extent already, but it was mostly focused on modifying existing files, and writes local to the PC. So I wrote up an example script using mcresources, which is Alcatraz's library for python datagen, and showed how resource generation might look in your mod. I can help work on getting this together so that in theory the resource gen could be converted to a single data script. If that sounds lame or like too much work, just say no and I'll go on my way.