### PR TITLE
Remove warning log when checking basalt columns

### DIFF
--- a/src/main/java/com/telepathicgrunt/repurposedstructures/mixin/features/NoBasaltColumnsInStructuresMixin.java
+++ b/src/main/java/com/telepathicgrunt/repurposedstructures/mixin/features/NoBasaltColumnsInStructuresMixin.java
@@ -34,7 +34,6 @@ public class NoBasaltColumnsInStructuresMixin {
 
         SectionPos sectionPos = SectionPos.of(mutableBlockPos);
         if (!levelAccessor.getChunk(sectionPos.x(), sectionPos.z()).getStatus().isOrAfter(ChunkStatus.STRUCTURE_REFERENCES)) {
-            RepurposedStructures.LOGGER.warn("Repurposed Structures: Detected a mod with a broken basalt columns configuredfeature that is trying to place blocks outside the 3x3 safe chunk area for features. Find the broken mod and report to them to fix the placement of their basalt columns feature.");
             return;
         }
 


### PR DESCRIPTION
Dear author,

https://github.com/TelepathicGrunt/RepurposedStructures/issues/329

According to the closed issue above, this log might have been deleted already, but actually as checks, it still contains within some old branches, and sometimes it will cause the log spamming and server lagging issue.

So kindly request for merging this commit into the following branches which have not deleted this log:

* 1.18-Fabric
* 1.18-Forge
* 1.18.2-Fabric
* 1.18.2-Forge
* 1.19.0-Fabric
* 1.19.0-Forge
* 1.19.0-Quilt
* 1.19.3-Fabric
* 1.19.3-Forge
* 1.19.3-Quilt

Many thanks <3